### PR TITLE
Don’t throw when nodeRequire from Browser

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -37,7 +37,7 @@ var util = {
   isBrowser: function isBrowser() { return process && process.browser; },
   isNode: function isNode() { return !util.isBrowser(); },
   nodeRequire: function nodeRequire(module) {
-    if (util.isNode()) return require(module);
+    if (util.isNode()) return require(module); else return {};
   },
   multiRequire: function multiRequire(module1, module2) {
     return require(util.isNode() ? module1 : module2);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "homepage": "https://github.com/grimurjonsson/aws-sdk-js",
     "contributors": [
       "Grimur Jonsson <grimur@jonsson.is>",
+      "runarberg <runarberg@zoho.com>",
       "Skossi <thorsteinng@greenqloud.com>"
     ],
     "devDependencies": {


### PR DESCRIPTION
The pattern `AWS.util.nodeRequire('foo').bar` is troublesome indeed. If
—for whatever reason— one ends up calling this from the client, it will
brutally panic. This can be a major problem for some bundle system and
transpilers, and can the complile to fail.
